### PR TITLE
add new line before first constant slot

### DIFF
--- a/src/checkers/inference/model/serialization/ToStringSerializer.java
+++ b/src/checkers/inference/model/serialization/ToStringSerializer.java
@@ -51,16 +51,19 @@ public class ToStringSerializer implements Serializer {
         List<String> slotStrings = new ArrayList<>();
 
         for (Slot slot : slots) {
-            String constraintString = delimiter + slot.serialize(this);
-            slotStrings.add(constraintString);
+            slotStrings.add(slot.serialize(this).toString());
         }
 
         // Sort list so that the output string is always in the same order
         Collections.sort(slotStrings);
 
         StringBuilder sb = new StringBuilder();
+        boolean first = true;
         for (String string : slotStrings) {
-            sb.append(string);
+            String slotString = first ? "" : delimiter;
+            slotString += string;
+            sb.append(slotString);
+            first = false;
         }
 
         return sb.toString();
@@ -69,20 +72,20 @@ public class ToStringSerializer implements Serializer {
     public String serializeConstraints(Iterable<Constraint> constraints, String delimiter) {
         List<String> constraintStrings = new ArrayList<>();
 
-        boolean first = true;
         for (Constraint constraint : constraints) {
-            String constraintString = first ? "" : delimiter +
-                    constraint.serialize(this);
-            constraintStrings.add(constraintString);
-            first = false;
+            constraintStrings.add(constraint.serialize(this).toString());
         }
 
         // Sort list so that the output string is always in the same order
         Collections.sort(constraintStrings);
 
         StringBuilder sb = new StringBuilder();
+        boolean first = true;
         for (String string : constraintStrings) {
-            sb.append(string);
+            String constraintString = first ? "" : delimiter;
+            constraintString += string;
+            sb.append(constraintString);
+            first = false;
         }
 
         return sb.toString();

--- a/src/checkers/inference/model/serialization/ToStringSerializer.java
+++ b/src/checkers/inference/model/serialization/ToStringSerializer.java
@@ -1,12 +1,5 @@
 package checkers.inference.model.serialization;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import javax.lang.model.type.DeclaredType;
-
 import checkers.inference.model.CombVariableSlot;
 import checkers.inference.model.CombineConstraint;
 import checkers.inference.model.ComparableConstraint;
@@ -22,6 +15,13 @@ import checkers.inference.model.Serializer;
 import checkers.inference.model.Slot;
 import checkers.inference.model.SubtypeConstraint;
 import checkers.inference.model.VariableSlot;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.lang.model.type.DeclaredType;
 
 /**
  * This Serializer is meant only to convert constraints and variables to

--- a/src/checkers/inference/model/serialization/ToStringSerializer.java
+++ b/src/checkers/inference/model/serialization/ToStringSerializer.java
@@ -1,5 +1,12 @@
 package checkers.inference.model.serialization;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.lang.model.type.DeclaredType;
+
 import checkers.inference.model.CombVariableSlot;
 import checkers.inference.model.CombineConstraint;
 import checkers.inference.model.ComparableConstraint;
@@ -15,13 +22,6 @@ import checkers.inference.model.Serializer;
 import checkers.inference.model.Slot;
 import checkers.inference.model.SubtypeConstraint;
 import checkers.inference.model.VariableSlot;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import javax.lang.model.type.DeclaredType;
 
 /**
  * This Serializer is meant only to convert constraints and variables to
@@ -50,12 +50,9 @@ public class ToStringSerializer implements Serializer {
     public String serializeSlots(Iterable<Slot> slots, String delimiter) {
         List<String> slotStrings = new ArrayList<>();
 
-        boolean first = true;
         for (Slot slot : slots) {
-            String constraintString = first ? "" : delimiter;
-            constraintString += slot.serialize(this);
+            String constraintString = delimiter + slot.serialize(this);
             slotStrings.add(constraintString);
-            first = false;
         }
 
         // Sort list so that the output string is always in the same order

--- a/src/checkers/inference/solver/DebugSolver.java
+++ b/src/checkers/inference/solver/DebugSolver.java
@@ -1,17 +1,5 @@
 package checkers.inference.solver;
 
-import checkers.inference.InferenceSolution;
-import checkers.inference.InferenceSolver;
-import checkers.inference.model.CombVariableSlot;
-import checkers.inference.model.ConstantSlot;
-import checkers.inference.model.Constraint;
-import checkers.inference.model.ExistentialVariableSlot;
-import checkers.inference.model.RefinementVariableSlot;
-import checkers.inference.model.Slot;
-import checkers.inference.model.VariableSlot;
-import checkers.inference.model.serialization.ToStringSerializer;
-import checkers.inference.util.InferenceUtil;
-
 import org.checkerframework.framework.type.QualifierHierarchy;
 
 import java.io.File;
@@ -26,6 +14,17 @@ import java.util.Map.Entry;
 
 import javax.annotation.processing.ProcessingEnvironment;
 
+import checkers.inference.InferenceSolution;
+import checkers.inference.InferenceSolver;
+import checkers.inference.model.CombVariableSlot;
+import checkers.inference.model.ConstantSlot;
+import checkers.inference.model.Constraint;
+import checkers.inference.model.ExistentialVariableSlot;
+import checkers.inference.model.RefinementVariableSlot;
+import checkers.inference.model.Slot;
+import checkers.inference.model.VariableSlot;
+import checkers.inference.model.serialization.ToStringSerializer;
+import checkers.inference.util.InferenceUtil;
 
 /**
  * Debug solver prints out variables and constraints.
@@ -53,18 +52,19 @@ public class DebugSolver implements InferenceSolver {
         final Map<Class<? extends Slot>, List<Slot>> typesToSlots = partitionSlots(slots);
         serializer.setIndent(1);
 
+        StringBuilder stringBuilder = new StringBuilder();
         for (final Entry<Class<? extends Slot>, List<Slot>> entry : typesToSlots.entrySet()) {
             final Class<? extends Slot> type = entry.getKey();
             final List<Slot> slotsForType = entry.getValue();
-            StringBuilder stringBuilder = new StringBuilder("\n");
-            stringBuilder.append("Created " + type.getSimpleName() + "\n");
+
+            stringBuilder.append("\nCreated " + type.getSimpleName() + "\n");
             stringBuilder.append(serializer.serializeSlots(slotsForType, "\n"));
             System.out.print(stringBuilder.toString());
             output.add(stringBuilder.toString());
+            stringBuilder.setLength(0);
         }
 
-        StringBuilder stringBuilder = new StringBuilder("\n");
-        stringBuilder.append("Created these constraints:\n");
+        stringBuilder.append("\n\nCreated these constraints:\n");
         stringBuilder.append(serializer.serializeConstraints(constraints, "\n"));
         stringBuilder.append("\n");
 
@@ -72,6 +72,7 @@ public class DebugSolver implements InferenceSolver {
         System.out.flush();
 
         output.add(stringBuilder.toString());
+        stringBuilder = null;
 
         if (configuration.containsKey(constraintFile)) {
             String filename = configuration.get(constraintFile);

--- a/src/checkers/inference/solver/DebugSolver.java
+++ b/src/checkers/inference/solver/DebugSolver.java
@@ -1,5 +1,17 @@
 package checkers.inference.solver;
 
+import checkers.inference.InferenceSolution;
+import checkers.inference.InferenceSolver;
+import checkers.inference.model.CombVariableSlot;
+import checkers.inference.model.ConstantSlot;
+import checkers.inference.model.Constraint;
+import checkers.inference.model.ExistentialVariableSlot;
+import checkers.inference.model.RefinementVariableSlot;
+import checkers.inference.model.Slot;
+import checkers.inference.model.VariableSlot;
+import checkers.inference.model.serialization.ToStringSerializer;
+import checkers.inference.util.InferenceUtil;
+
 import org.checkerframework.framework.type.QualifierHierarchy;
 
 import java.io.File;
@@ -13,18 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.processing.ProcessingEnvironment;
-
-import checkers.inference.InferenceSolution;
-import checkers.inference.InferenceSolver;
-import checkers.inference.model.CombVariableSlot;
-import checkers.inference.model.ConstantSlot;
-import checkers.inference.model.Constraint;
-import checkers.inference.model.ExistentialVariableSlot;
-import checkers.inference.model.RefinementVariableSlot;
-import checkers.inference.model.Slot;
-import checkers.inference.model.VariableSlot;
-import checkers.inference.model.serialization.ToStringSerializer;
-import checkers.inference.util.InferenceUtil;
 
 /**
  * Debug solver prints out variables and constraints.


### PR DESCRIPTION
The previous `ToStringSerializer` didn't add `\n` before the first constant slot, so the output of constant slot is:
```
( 81 => @DataFlowTop )
( 82 => @DataFlowTop )
( 83 => @DataFlowTop )( 1 => @DataFlow )
```
and this commit makes the format better.