### PR TITLE
add plume-lib source dependency, exclude junit-4.10

### DIFF
--- a/.travis-build-without-test.sh
+++ b/.travis-build-without-test.sh
@@ -25,4 +25,14 @@ fi
 # This also builds annotation-tools and jsr308-langtools
 (cd $ROOT/checker-framework/ && ./.travis-build-without-test.sh)
 
+## Build plume-lib
+if [ -d $ROOT/plume-lib ] ; then
+    # Older versions of git don't support the -C command-line option
+    (cd $ROOT/plume-lib && git pull)
+else
+    (cd $ROOT && git clone https://github.com/mernst/plume-lib.git)
+fi
+
+(cd $ROOT/plume-lib/ && make)
+
 gradle dist

--- a/build.gradle
+++ b/build.gradle
@@ -109,19 +109,25 @@ def afuDir        = env["AFU"] ?: jsr308Child("annotation-tools/annotation-file-
 //afuDir as its parent
 def afuChild      = fromBaseDir.curry(afuDir)
 
+def plumeDir        = env["PLUME"] ?: jsr308Child("plume-lib")
+def plumeChild      = fromBaseDir.curry(plumeDir)
+
 //JarsToPackage contains both all members that should be on the classpath for this build
 //and all jars (except for checker-framework-inference.jar) that should be included in
 //the jar produced by the allJars command
 def jarsToPackage = [ //Annotation File Utilities paths        //TODO: AFU Jar has some things that are also in checkers.jar
                         "annotation-file-utilities.jar",
-                        "lib/plume.jar"
                     ].collect { afuChild(it).getAbsolutePath()      } +
 
                     [//checker relative paths
                         "checker/dist/$jreJarName",
                         "checker/dist/javac.jar",
                         "checker/dist/checker.jar",
-                    ].collect { checkersChild(it).getAbsolutePath() }
+                    ].collect { checkersChild(it).getAbsolutePath() } +
+
+                    [//plume relative paths
+                        "java/plume.jar"
+                    ].collect {plumeChild(it).getAbsolutePath() }
 
 //A list of files to append to the class path during compilation
 def toPackageClasspath = files(

--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,7 @@ task copytest(type : Copy) {
 
             })
     from tasks.getByPath('compileJava').getClasspath().filter(
+    		//Filter out junit-4.10.jar, so that junit-4.12.jar can be used in testing.  
             { f -> f.getName().endsWith(".jar") && !f.getName().equals("rt.jar") && !f.getName().equals("tools.jar") && !f.getName().equals("junit-4.10.jar")
             })
     from file(checkerInferenceJar)

--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ task copytest(type : Copy) {
 
             })
     from tasks.getByPath('compileJava').getClasspath().filter(
-            { f -> f.getName().endsWith(".jar") && !f.getName().equals("rt.jar") && !f.getName().equals("tools.jar")
+            { f -> f.getName().endsWith(".jar") && !f.getName().equals("rt.jar") && !f.getName().equals("tools.jar") && !f.getName().equals("junit-4.10.jar")
             })
     from file(checkerInferenceJar)
     into file('tests/deps')


### PR DESCRIPTION
Two changes related to the update in annotation-tools:
1. plume-lib is independent from annotation-tools now, so plume.jar should be found in jsr308Child path.
2. It seems that annotation-file-utilities.jar no longer contains junit-4.12.jar, and junit-4.10 is putted in to `deps` directory somehow... So the testing process fails when the method in junit-4.12.jar is called. Simply excluding junit-4.10 can fix this. (It seems that junit-4.10 is required by json-simple-1.1.1 project, so we may have to exclude junit-4.10 manually...)

 