### PR TITLE
Explicitly call SystemClassLoader load class in InferenceMain

### DIFF
--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -284,13 +284,8 @@ public class InferenceMain {
     private InferrableChecker getRealChecker() {
         if (realChecker == null) {
             try {
-                File root = new File(InferenceOptions.checkersInferenceDir
-                        .getParentFile().toString());
-                URLClassLoader classLoader = URLClassLoader
-                        .newInstance(new URL[] { root.toURI().toURL() });
                 realChecker = (InferrableChecker) Class.forName(
-                        InferenceOptions.checker, true, classLoader)
-                        .newInstance();
+                        InferenceOptions.checker, true, ClassLoader.getSystemClassLoader()).newInstance();
                 realChecker.init(inferenceChecker.getProcessingEnvironment());
                 realChecker.initChecker();
                 logger.finer(String.format("Created real checker: %s", realChecker));
@@ -338,12 +333,8 @@ public class InferenceMain {
 
     protected InferenceSolver getSolver() {
         try {
-            File root = new File(InferenceOptions.checkersInferenceDir
-                    .getParentFile().toString());
-            URLClassLoader classLoader = URLClassLoader
-                    .newInstance(new URL[] { root.toURI().toURL() });
             InferenceSolver solver = (InferenceSolver) Class.forName(
-                    InferenceOptions.solver, true, classLoader).newInstance();
+                    InferenceOptions.solver, true, ClassLoader.getSystemClassLoader()).newInstance();
             logger.finer("Created solver: " + solver);
             return solver;
         } catch (Throwable e) {


### PR DESCRIPTION
In `InferenceMain#getRealChecker(`) and `InferenceMain#getSolver()`, we have code using `URLClassLoader` to load Checker class and Solver class.

However, this code is confusing and misleading, because the parent directory of `checker-framework-Inference` is never an effective `bin dir` that directly contains .class files. Also, an instance of `URLClassLoader` will not do a recursive searching of it's URLs, which means the `URLClassLoader` will never load classes by itself.

The previous code accidentally works when shell script has export classpath of Checker and Solver in environment variable `CLASSPATH`. This is because `SystemClassLoader` is an ancestor class of `URLClassLoader`,  and thus the class files of Checker and Solver is actually loaded by `SystemClassLoader` through env variable `CLASSPATH`.

To make code be clearer on it's real behaviour, I changed code to explicitly call `SystemClassLoader` to load Checker and Solver class files.

- Reference: [Understand JAVA Classloader by IBM](http://www.ibm.com/developerworks/java/tutorials/j-classloader/j-classloader.html)
