### PR TITLE
Avoid NPE

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1615,7 +1615,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
             @Override
             protected Boolean scan(AnnotatedTypeMirror type, Void aVoid) {
-                if (InferenceQualifierHierarchy.findVarAnnot(type.getAnnotations()) != null) {
+                if (type != null && InferenceQualifierHierarchy.findVarAnnot(type.getAnnotations()) != null) {
                     return true;
                 }
                 Boolean superCall = super.scan(type, aVoid);

--- a/src/checkers/inference/util/ConstantToVariableAnnotator.java
+++ b/src/checkers/inference/util/ConstantToVariableAnnotator.java
@@ -48,7 +48,7 @@ public class ConstantToVariableAnnotator extends AnnotatedTypeScanner<Void, Void
     @Override
     protected Void scan(AnnotatedTypeMirror type, Void aVoid) {
 
-        if (!type.getAnnotations().isEmpty()) {
+        if (type != null && !type.getAnnotations().isEmpty()) {
             addVariablePrimaryAnnotation(type);
         }
         super.scan(type, null);


### PR DESCRIPTION
Because of changes in https://github.com/typetools/checker-framework/pull/1511, the type scanned in an AnnotatedTypeScanner might be null.