### PR TITLE
Make InferenceEqualityComparer a proper inner class

### DIFF
--- a/src/checkers/inference/InferenceTypeHierarchy.java
+++ b/src/checkers/inference/InferenceTypeHierarchy.java
@@ -6,7 +6,6 @@ import org.checkerframework.framework.type.DefaultTypeHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.StructuralEqualityComparer;
 import org.checkerframework.framework.type.StructuralEqualityVisitHistory;
-import org.checkerframework.framework.type.SubtypeVisitHistory;
 import org.checkerframework.javacutil.BugInCF;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -53,46 +52,46 @@ public class InferenceTypeHierarchy extends DefaultTypeHierarchy {
         return new InferenceEqualityComparer(this.typeargVisitHistory,
                 InferenceQualifierHierarchy.findVarAnnot(qualifierHierarchy.getTopAnnotations()));
     }
-}
 
-class InferenceEqualityComparer extends StructuralEqualityComparer {
+    private static class InferenceEqualityComparer extends StructuralEqualityComparer {
 
-    private final AnnotationMirror varAnnot;
+        private final AnnotationMirror varAnnot;
 
-    public InferenceEqualityComparer(StructuralEqualityVisitHistory typeargVisitHistory, AnnotationMirror varAnnot) {
+        public InferenceEqualityComparer(StructuralEqualityVisitHistory typeargVisitHistory, AnnotationMirror varAnnot) {
             super(typeargVisitHistory);
             this.varAnnot = varAnnot;
-    }
+        }
 
-    @Override
-    protected boolean arePrimeAnnosEqual(AnnotatedTypeMirror type1, AnnotatedTypeMirror type2) {
-        final InferenceMain inferenceMain = InferenceMain.getInstance();
-        final AnnotationMirror varAnnot1 = type1.getAnnotationInHierarchy(varAnnot);
-        final AnnotationMirror varAnnot2 = type2.getAnnotationInHierarchy(varAnnot);
+        @Override
+        protected boolean arePrimeAnnosEqual(AnnotatedTypeMirror type1, AnnotatedTypeMirror type2) {
+            final InferenceMain inferenceMain = InferenceMain.getInstance();
+            final AnnotationMirror varAnnot1 = type1.getAnnotationInHierarchy(varAnnot);
+            final AnnotationMirror varAnnot2 = type2.getAnnotationInHierarchy(varAnnot);
 
-        // TODO: HackMode
-        if (InferenceMain.isHackMode((varAnnot1 == null || varAnnot2 == null))) {
-            InferenceMain.getInstance().logger.warning(
-                "Hack:InferenceTYpeHierarchy:66\n"
-              + "type1=" + type1 + "\n"
-              + "type2=" + type2 + "\n"
-            );
+            // TODO: HackMode
+            if (InferenceMain.isHackMode((varAnnot1 == null || varAnnot2 == null))) {
+                InferenceMain.getInstance().logger.warning(
+                        "Hack:InferenceTYpeHierarchy:66\n"
+                                + "type1=" + type1 + "\n"
+                                + "type2=" + type2 + "\n"
+                );
+                return true;
+            }
+
+            if (varAnnot1 == null || varAnnot2 == null) {
+                throw new BugInCF("Calling InferenceTypeHierarchy.arePrimeAnnosEqual on type with"
+                        + "no varAnnots.!\n"
+                        + "type1=" + type1 + "\n"
+                        + "type2=" + type2);
+            }
+
+            if (!inferenceMain.isPerformingFlow()) {
+                final Slot leftSlot  = inferenceMain.getSlotManager().getSlot( varAnnot1 );
+                final Slot rightSlot = inferenceMain.getSlotManager().getSlot( varAnnot2 );
+                inferenceMain.getConstraintManager().add(new EqualityConstraint(leftSlot, rightSlot));
+            }
+
             return true;
         }
-
-        if (varAnnot1 == null || varAnnot2 == null) {
-            throw new BugInCF("Calling InferenceTypeHierarchy.arePrimeAnnosEqual on type with"
-                    + "no varAnnots.!\n"
-                    + "type1=" + type1 + "\n"
-                    + "type2=" + type2);
-        }
-
-        if (!inferenceMain.isPerformingFlow()) {
-            final Slot leftSlot  = inferenceMain.getSlotManager().getSlot( varAnnot1 );
-            final Slot rightSlot = inferenceMain.getSlotManager().getSlot( varAnnot2 );
-            inferenceMain.getConstraintManager().add(new EqualityConstraint(leftSlot, rightSlot));
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
This PR is to fix the following bug:
`InferenceEqualityComparer` is not a proper inner class in file `InferenceTypeHierarchy`, and sometimes the compiled file (`InferenceEqualityComparer.class`) is missing, causing `NoClassDefFoundError`.

This could be a bug in Gradle since it is gone after turning off the incremental compilation:
```
tasks.withType(JavaCompile) {
    options.incremental = false
}
```

@wmdietl 