### PR TITLE
Revert "Remove javacJar as a compile dependencies."

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     }
 
     compile files("${checkerJar}")
+    compile group: 'com.google.errorprone', name: 'javac', version: "$errorproneJavacVersion"
 
     compile 'org.plumelib:options:1.0.4'
     // Serialize constraints
@@ -133,10 +134,6 @@ compileJava {
             '-Xlint:deprecation',
             '-Werror',
     ]
-    options.fork = true
-    if (isJava8) {
-        options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.javacJar.asPath}"]
-    }
 }
 
 // Exclude parts of the build directory that don't include classes from being packaged in


### PR DESCRIPTION
Reverts typetools/checker-framework-inference#143

The build.gradle file needs to be update to work with JDK 11 and then javac.jar can be removed.